### PR TITLE
v 2.1.2 -- Lower minimum required version from .NET 8 to .NET 6

### DIFF
--- a/src/CESMII.OpcUa.CloudLibraryResolver.DependencyInjection/CESMII.OpcUa.CloudLibraryResolver.DependencyInjection.csproj
+++ b/src/CESMII.OpcUa.CloudLibraryResolver.DependencyInjection/CESMII.OpcUa.CloudLibraryResolver.DependencyInjection.csproj
@@ -6,14 +6,14 @@
     <Configurations>Debug;Release;Staging</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageIcon>cesmii.png</PackageIcon>
-	<Version>0.2-beta</Version>
+	<Version>2.1.2</Version>
 	<Authors>Markus Horstmann</Authors>
-	<Company>CESMII</Company>
-	<Product></Product>
+  <Company>CESMII/C-Labs</Company>
+  <Product></Product>
 	<NeutralLanguage>en</NeutralLanguage>
 	<Description>OPC UA Cloud Library Resolver: Extensions for using the resolver with DI.</Description>
-	<Copyright>Copyright © 2022 CESMII</Copyright>
-	<PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+  <Copyright>Copyright © 2022-2024 CESMII. All rights reserved.</Copyright>
+  <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,9 +22,9 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
 	</ItemGroup>
 
 

--- a/src/CESMII.OpcUa.CloudLibraryResolver/CESMII.OpcUa.CloudLibraryResolver.csproj
+++ b/src/CESMII.OpcUa.CloudLibraryResolver/CESMII.OpcUa.CloudLibraryResolver.csproj
@@ -6,14 +6,14 @@
     <Configurations>Debug;Release;Staging</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageIcon>cesmii.png</PackageIcon>
-	<Version>0.2-beta</Version>
-	<Authors>Markus Horstmann</Authors>
-	<Company>CESMII</Company>
-	<Product></Product>
+  <Version>2.1.2</Version>
+  <Authors>Markus Horstmann</Authors>
+  <Company>CESMII/C-Labs</Company>
+  <Product></Product>
 	<NeutralLanguage>en</NeutralLanguage>
 	<Description>OPC UA Cloud Library Resolver for the CESMII NodeSetImporter.</Description>
-	<Copyright>Copyright © 2022 CESMII</Copyright>
-	<PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+  <Copyright>Copyright © 2022-2024 CESMII. All rights reserved.</Copyright>
+  <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/src/CESMII.OpcUa.NodeSetImporter/CESMII.OpcUa.NodeSetImporter.csproj
+++ b/src/CESMII.OpcUa.NodeSetImporter/CESMII.OpcUa.NodeSetImporter.csproj
@@ -6,14 +6,14 @@
     <Configurations>Debug;Release;Staging</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	  <PackageIcon>cesmii.png</PackageIcon>
-	  <Version>0.1</Version>
-	  <Authors>Chris Muench, Markus Horstmann</Authors>
-	  <Company>CESMII</Company>
-	  <Product></Product>
+    <Version>2.1.2</Version>
+    <Authors>Chris Muench, Markus Horstmann</Authors>
+    <Company>CESMII/C-Labs</Company>
+    <Product></Product>
 	  <NeutralLanguage>en</NeutralLanguage>
 	  <Description>OPC UA Node Set Importer: stores nodeset files and resolves their dependencies.</Description>
-	  <Copyright>Copyright © 2022 CESMII</Copyright>
-	  <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+    <Copyright>Copyright © 2022-2024 CESMII. All rights reserved.</Copyright>
+    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/src/CESMII.OpcUa.NodeSetModel.EF/CESMII.OpcUa.NodeSetModel.EF.csproj
+++ b/src/CESMII.OpcUa.NodeSetModel.EF/CESMII.OpcUa.NodeSetModel.EF.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <Configurations>Debug;Release;Staging</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageIcon>cesmii.png</PackageIcon>
-	<Version>0.1</Version>
-	<Authors>Markus Horstmann</Authors>
-	<Company>CESMII</Company>
-	<Product></Product>
+  <Version>2.1.2</Version>
+  <Authors>Markus Horstmann</Authors>
+  <Company>CESMII/C-Labs</Company>
+  <Product></Product>
 	<NeutralLanguage>en</NeutralLanguage>
 	<Description>OPC UA Node Set Model mapping for Entity Framework</Description>
-	<Copyright>Copyright © 2022 CESMII</Copyright>
-	<PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+  <Copyright>Copyright © 2022-2024 CESMII. All rights reserved.</Copyright>
+  <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 
 	<ItemGroup>
@@ -20,9 +20,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
-	<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.7" />
-	<PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="8.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="6.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CESMII.OpcUa.NodeSetModel.Factory.Opc/CESMII.OpcUa.NodeSetModel.Factory.Opc.csproj
+++ b/src/CESMII.OpcUa.NodeSetModel.Factory.Opc/CESMII.OpcUa.NodeSetModel.Factory.Opc.csproj
@@ -6,14 +6,14 @@
 	<LangVersion>latest</LangVersion>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageIcon>cesmii.png</PackageIcon>
-	<Version>0.1</Version>
-	<Authors>Markus Horstmann</Authors>
-	<Company>CESMII</Company>
-	<Product></Product>
+  <Version>2.1.2</Version>
+  <Authors>Markus Horstmann</Authors>
+  <Company>CESMII/C-Labs</Company>
+  <Product></Product>
 	<NeutralLanguage>en</NeutralLanguage>
 	<Description>OPC UA Node Set Model factory: creates a Node Set Model from an OPC UA node set file.</Description>
-	<Copyright>Copyright © 2022 CESMII</Copyright>
-	<PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+  <Copyright>Copyright © 2022-2024 CESMII. All rights reserved.</Copyright>
+  <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/src/CESMII.OpcUa.NodeSetModel.Factory.OpcClient/CESMII.OpcUa.NodeSetModel.Factory.OpcClient.csproj
+++ b/src/CESMII.OpcUa.NodeSetModel.Factory.OpcClient/CESMII.OpcUa.NodeSetModel.Factory.OpcClient.csproj
@@ -6,14 +6,14 @@
 	<LangVersion>latest</LangVersion>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageIcon>cesmii.png</PackageIcon>
-	<Version>0.1</Version>
-	<Authors>Markus Horstmann</Authors>
-	<Company>CESMII</Company>
-	<Product></Product>
+  <Version>2.1.2</Version>
+  <Authors>Markus Horstmann</Authors>
+  <Company>CESMII/C-Labs</Company>
+  <Product></Product>
 	<NeutralLanguage>en</NeutralLanguage>
 	<Description>OPC UA Node Set Model factory: creates a Node Set Model from an OPC UA server.</Description>
-	<Copyright>Copyright © 2022 CESMII</Copyright>
-	<PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+  <Copyright>Copyright © 2022-2024 CESMII. All rights reserved.</Copyright>
+  <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/src/CESMII.OpcUa.NodeSetModel/CESMII.OpcUa.NodeSetModel.csproj
+++ b/src/CESMII.OpcUa.NodeSetModel/CESMII.OpcUa.NodeSetModel.csproj
@@ -5,14 +5,14 @@
     <Configurations>Debug;Release;Staging</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageIcon>cesmii.png</PackageIcon>
-	<Version>0.1</Version>
-	<Authors>Markus Horstmann</Authors>
-	<Company>CESMII</Company>
-	<Product></Product>
+  <Version>2.1.2</Version>
+  <Authors>Markus Horstmann</Authors>
+  <Company>CESMII/C-Labs</Company>
+  <Product></Product>
 	<NeutralLanguage>en</NeutralLanguage>
 	<Description>OPC UA Node Set Model: provides a fully populated graph of a node set and its dependencies.</Description>
-	<Copyright>Copyright © 2022 CESMII</Copyright>
-	<PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+  <Copyright>Copyright © 2022-2024 CESMII. All rights reserved.</Copyright>
+  <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
 	<LangVersion>Latest</LangVersion>
   </PropertyGroup>
 

--- a/src/CESMII.OpcUa.NodeSetValidator/CESMII.OpcUa.NodeSetValidator.csproj
+++ b/src/CESMII.OpcUa.NodeSetValidator/CESMII.OpcUa.NodeSetValidator.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 		<AssemblyName>CESMII.OpcUa.NodeSetValidator</AssemblyName>
 		<RootNamespace>CESMII.OpcUa.NodeSetValidator</RootNamespace>
 		<PackageId>CESMII.OpcUa.NodeSetValidator</PackageId>
-		<Version>1.0.0</Version>
-		<Authors>Chris Muench</Authors>
+    <Version>2.1.2</Version>
+    <Authors>Chris Muench</Authors>
 		<Company>CESMII/C-Labs</Company>
 		<Product>OPC UA NodeSet Validator</Product>
-		<Copyright>Copyright © 2023 CESMII/C-Labs</Copyright>
-		<ProjectName>$(AssemblyName).$(TargetFramework)</ProjectName>
+    <Copyright>Copyright © 2022-2024 CESMII. All rights reserved.</Copyright>
+    <ProjectName>$(AssemblyName).$(TargetFramework)</ProjectName>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<LangVersion>latest</LangVersion>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -20,7 +20,7 @@
 	<ItemGroup>
 		<PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.5.374.78" />
 		<PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Symbols" Version="1.5.374.78" />
-		<PackageReference Include="System.Text.Json" Version="8.0.4" />
+		<PackageReference Include="System.Text.Json" Version="6.0.4" />
 	</ItemGroup>
 
 

--- a/src/Tests/CESMII.NodeSetUtilities.Tests/CESMII.NodeSetUtilities.Tests.csproj
+++ b/src/Tests/CESMII.NodeSetUtilities.Tests/CESMII.NodeSetUtilities.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.12" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/src/Tests/NodeSetDiffLibrary/CESMII.OpcUa.NodeSetDiff.csproj
+++ b/src/Tests/NodeSetDiffLibrary/CESMII.OpcUa.NodeSetDiff.csproj
@@ -4,13 +4,14 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageIcon>cesmii.png</PackageIcon>
-		<Authors>Markus Horstmann, Chris Muench</Authors>
-		<Company>CESMII</Company>
-		<Product></Product>
+    <Version>2.1.2</Version>
+    <Authors>Markus Horstmann, Chris Muench</Authors>
+    <Company>CESMII/C-Labs</Company>
+    <Product></Product>
 		<NeutralLanguage>en</NeutralLanguage>
 		<Description>OPC UA Node Set Diffing tool.</Description>
-		<Copyright>Copyright © 2022 CESMII</Copyright>
-		<PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+    <Copyright>Copyright © 2022-2024 CESMII. All rights reserved.</Copyright>
+    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Include=".\..\..\cesmii.png" Pack="true" PackagePath="" />


### PR DESCRIPTION
Update last month pushed the minimum required .NET version from .NET 6.x to .NET 8.x. This wasn't necessary, so am pushing it back down to minimize the impact on existing projects that do not need / do not want to have to update their dependencies.